### PR TITLE
Fix the bug with not falling back to unrar when 7z fails

### DIFF
--- a/ansible-playbook/roles/container-stack-media-server/files/post-torrent-download.sh
+++ b/ansible-playbook/roles/container-stack-media-server/files/post-torrent-download.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 function log () {
     logger -t "post-torrent-download" "$1"
 }
@@ -13,8 +14,19 @@ fi
 log "Processing : $DOWNLOAD_PATH"
 ls $DOWNLOAD_PATH/*.rar 1>/dev/null 2>/dev/null || (log "No rar file found in $DOWNLOAD_PATH. Exiting" && exit 0)
 
+FILE_COUNT=$(ls -1 "$DOWNLOAD_PATH" | wc -l)
+log "Found $FILE_COUNT files in $TR_TORRENT_DIR"
+
 COMPLETED=0
 find "$DOWNLOAD_PATH" -name "*.rar" -execdir 7z e "{}" \; && log "Extracted using 7z: $DOWNLOAD_PATH" && COMPLETED=1
+
+FILE_COUNT_AFTER_7Z=$(ls -1 "$DOWNLOAD_PATH" | wc -l)
+log "Found $FILE_COUNT_AFTER_7Z files after 7z extraction"
+
+if [ "$FILE_COUNT" -eq "$FILE_COUNT_AFTER_7Z" ]; then
+  echo "Rar extraction with 7z failed, retrying with unrar";
+  COMPLETED=0
+fi
 
 if [ "$COMPLETED" -eq "0" ]; then
   find "$DOWNLOAD_PATH" -name "*.rar" -execdir unrar e "{}" \; && log "Extracted using unrar: $DOWNLOAD_PATH" && COMPLETED=1


### PR DESCRIPTION
7z failed to exit with the correct exitcode when run into a certain issue in arm env. Added an alternate state check to see if any file created in the working directory (i.e the extracted file(s)) and if not fallback to unrar