### PR TITLE
Replacing NordLynx vpn container with Gluetun because NordLynx is no …

### DIFF
--- a/ansible-playbook/roles/container-stack-media-server/tasks/main.yml
+++ b/ansible-playbook/roles/container-stack-media-server/tasks/main.yml
@@ -17,6 +17,13 @@
     - "{{ qbittorrent_config_path }}"
   when: qbittorrent_enable|bool == true
 
+- name: Create vpn config directory
+  file:
+    path: "{{ vpn_config_path }}"
+    state: directory
+    owner: "{{ server_data_dir_user }}"
+    group: "{{ server_data_dir_group }}"
+
 - name: Install 7z to unpack rar files
   apt:
     name: [p7zip-full, p7zip]

--- a/ansible-playbook/roles/container-stack-media-server/templates/docker-compose-fragment-no-vpn.yml.j2
+++ b/ansible-playbook/roles/container-stack-media-server/templates/docker-compose-fragment-no-vpn.yml.j2
@@ -5,7 +5,7 @@ transmission:
   environment:
     - PUID={{ server_data_user_uid }}
     - PGID={{ server_data_group_gid }}
-    - TZ={{ server_timezone}}
+    - TZ={{ server_timezone }}
   volumes:
     - {{ transmission_config_path }}:/config
     - {{ transmission_download_path }}:/downloads
@@ -29,7 +29,7 @@ qbittorrent:
   environment:
     - PUID={{ server_data_user_uid }}
     - PGID={{ server_data_group_gid }}
-    - TZ={{ server_timezone}}
+    - TZ={{ server_timezone }}
     - WEBUI_PORT=8080
   volumes:
     - {{ qbittorrent_config_path }}:/config

--- a/ansible-playbook/roles/container-stack-media-server/templates/docker-compose-fragment-vpn-type-nordlynx.yml.j2
+++ b/ansible-playbook/roles/container-stack-media-server/templates/docker-compose-fragment-vpn-type-nordlynx.yml.j2
@@ -1,29 +1,23 @@
 vpn:
-  image: ghcr.io/bubuntux/nordlynx
+  image: qmcgaw/gluetun
   container_name: {{ vpn_container_name }}
   networks:
     - media_server_network
     - vpn_local
+  volumes:
+    - {{ vpn_config_path }}/gluetun:/gluetun
+  devices:
+    - /dev/net/tun:/dev/net/tun
   cap_add:
     - NET_ADMIN
-  sysctls:
-    - net.ipv4.conf.all.rp_filter=2
-    - net.ipv6.conf.all.disable_ipv6=1
-    - net.ipv4.conf.all.src_valid_mark=1
   environment:
-    - DNS=103.86.96.100,103.86.99.100
-    - PRIVATE_KEY={{ nordlynx_private_key.stdout_lines[0] }}
-    - NET_LOCAL={{ vpn_network_allow_cidr }}
-    - POST_UP=iptables -A INPUT -p tcp --dport 9091 -j ACCEPT
-{% if vpn_server_end_point is defined %}
-    - END_POINT={{ vpn_server_end_point }}
-{% endif %}
-{% if vpn_server_public_key is defined %}
-    - PUBLIC_KEY={{ vpn_server_public_key }}
-{% endif %}
-{% if vpn_nordvpn_query is defined %}
-    - QUERY={{ vpn_nordvpn_query }}
-{% endif %}
+    - VPN_SERVICE_PROVIDER=nordvpn
+    - VPN_TYPE=wireguard
+    - WIREGUARD_PRIVATE_KEY={{ nordlynx_private_key.stdout_lines[0] }}
+    - SERVER_COUNTRIES=Netherlands
+    - PUID={{ server_data_user_uid }}
+    - PGID={{ server_data_group_gid }}
+    - TZ={{ server_timezone }}
   ports:
 {% if transmission_enable == true %}
     - 9092:9091
@@ -34,7 +28,7 @@ vpn:
     - 8081:8080
 {% endif %}
   healthcheck:
-    test: ["CMD-SHELL", "curl -s https://web-api.nordvpn.com/v1/ips/info | jq -r '.protected' | grep 'true' || exit 1"]
+    test: ["CMD-SHELL", "wget -q -O - https://web-api.nordvpn.com/v1/ips/info | tr -d ' ' | grep -q '\"protected\":true' || exit 1"]
     interval: 1m30s
     timeout: 30s
     retries: 5

--- a/ansible-playbook/roles/container-stack-media-server/vars/main.yml
+++ b/ansible-playbook/roles/container-stack-media-server/vars/main.yml
@@ -39,6 +39,7 @@ vpn_server_end_point: "{{ gv_vpn_server_end_point }}"
 vpn_server_public_key: "{{ gv_vpn_server_public_key }}"
 vpn_nordvpn_query: "{{ gv_vpn_nordvpn_query }}"
 vpn_container_name: vpn
+vpn_config_path: "{{ container_data_root }}/{{ vpn_container_name }}/config"
 
 # sonarr
 sonarr_config_path_local: "{{ media_server_container_stack_location }}/additional-config/sonarr"


### PR DESCRIPTION
NordLynx is no longer maintained : Replaced it with [Gluetun](https://github.com/qdm12/gluetun)
 - uses less resources
 - more generic, few providers other than NordVPN
 - supports openvpn and wireguard both
 - DNS over TLS


